### PR TITLE
qualify strip-ansi-escapes dependency to rollback breaking change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 unicode-segmentation = "1"
-strip-ansi-escapes = "0"
+strip-ansi-escapes = "0.1"
 regex = { version = "1.7", optional = true }
 lazy_static = { version = "^1", optional = true }
 


### PR DESCRIPTION
The strip-ansi-escapes crate published a breaking change two weeks ago that prevents this crate from compiling (deleting your Cargo.lock will trigger the issue).

This pull request restricts automatic upgrades on that crate to patch updates.