### PR TITLE
Remove unnecessary expect, after breaking change in strip-ansi-escape 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 unicode-segmentation = "1"
-strip-ansi-escapes = "0"
+strip-ansi-escapes = "0.2"
 regex = { version = "1.7", optional = true }
 lazy_static = { version = "^1", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -989,7 +989,7 @@ impl Colonnade {
                 v.into_iter()
                     .map(|t| {
                         let s = t.to_string();
-                        let bytes = strip_ansi_escapes::strip(&s).expect(&format!("failed to strip ansi escape sequences from {}", s));
+                        let bytes = strip_ansi_escapes::strip(&s);
                         std::str::from_utf8(&bytes).expect(&format!("failed to restores bytes to utf8 string after stripping ansi escape sequences from {}", s)).to_string()
                     })
                     .collect::<Vec<String>>()


### PR DESCRIPTION
I suggest this as an alternative to #3. 
The breaking change in the dependency `strip-ansi-escape` changed the return type of `strip` because it could never fail. Hence removing the expect is a better solution.  